### PR TITLE
Add support for Appium v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.0.3] - 05-APR-2024
+
+### Fixed
+
+* `AppiumConnect.initialize_appium`, `AppiumServer.start`, and `AppiumServer.running?` methods now support Appium version 2.x.
+Backward compatibility with Appium version 1.x is provided if `APPIUM_SERVER_VERSION` Environment Variable is set to `1`.
+
+
 ## [4.0.2] - 27-MAR-2024
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 The TestCentricity™ Mobile core framework for native mobile iOS and Android app testing implements a Screen Object Model
-DSL for use with Cucumber (version 7.x or greater) and Appium. It also facilitates the configuration of the appropriate
+DSL for use with Cucumber (version 7.x or greater) and Appium 2.x. It also facilitates the configuration of the appropriate
 Appium capabilities and driver required to establish a connection with locally or cloud hosted iOS and Android real devices
 or simulators.
 
@@ -27,6 +27,15 @@ test targets:
 A complete history of bug fixes and new features can be found in the {file:CHANGELOG.md CHANGELOG} file.
 
 The RubyDocs for this gem can be found [here](https://www.rubydoc.info/gems/testcentricity_mobile/).
+
+Two example projects that demonstrates the implementation of a screen object model framework using Cucumber and TestCentricity™
+Mobile can be found at the following:
+  * [tc_mobile_react_native_demo](https://github.com/TestCentricity/tc_mobile_react_native_demo)
+  * [tc_mobile_wdio_demo](https://github.com/TestCentricity/tc_mobile_wdio_demo)
+
+Refer to [this wiki page](https://github.com/TestCentricity/testcentricity_mobile/wiki/XCUItest-driver-bug-impacts-iOS-dialogs-managed-by-com.apple.springboard) for
+information on a bug with the latest versions of the XCUItest driver that affects Appium's ability to interact with and
+verify iOS system level modal dialogs.
 
 
 ### Which gem should I use?
@@ -474,10 +483,19 @@ Single `AppUIElement` declarations have the following format:
     elementType :elementName, { locator_strategy: locator_identifier }
 
 * The `elementName` is the unique name that you will use to refer to the UI element and is specified as a `Symbol`.
-* The `locator_strategy` specifies the [selector strategy](https://appium.io/docs/en/commands/element/find-elements/index.html#selector-strategies) 
-that Appium will use to find the `AppUIElement`. Valid selectors are `accessibility_id:`, `id:`, `name:`, `class:`, `xpath:`, 
-`predicate:` (iOS only), `class_chain:` (iOS only), and `css:` (WebViews in hybrid apps only).
+* The `locator_strategy` specifies the selector strategy that Appium will use to find the `AppUIElement`. Valid selectors are:
+  - `accessibility_id:`
+  - `id:`
+  - `name:`
+  - `class:`
+  - `xpath:`
+  - `predicate:` (iOS only)
+  - `class_chain:` (iOS only)
+  - `css:` (WebViews in hybrid apps only).
 * The `locator_identifier` is the value or attribute that uniquely and unambiguously identifies the `AppUIElement`.
+
+Refer to [this page](https://appium.github.io/appium-xcuitest-driver/5.12/locator-strategies/) for information on selector strategies for iOS.
+Refer to [this page](https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#element-location) for information on selector strategies for Android.
 
 Multiple `AppUIElement` declarations for a collection of elements of the same type can be performed by passing a hash table
 containing the names and locators of each individual element.
@@ -974,6 +992,10 @@ Refer to [this page](https://appium.io/docs/en/2.4/guides/caps/) for information
 to invoking Cucumber to run your features/scenarios on locally hosted iOS or Android simulators or physical devices. Refer
 to [**section 8.2.3 (Starting and Stopping Appium Server)**](#starting-and-stopping-appium-server) below.
 
+⚠️ If you are running locally hosted mobile tests on iOS or Android simulators or devices using version 1.x of the Appium
+server, the `APPIUM_SERVER_VERSION` environment variable must be set to `1` in order to ensure that the correct Appium server
+endpoint is used.
+
 #### Connecting to Locally Hosted iOS Simulators or Physical Devices
 
 You can run your automated tests on locally hosted iOS simulators or physically connected devices using Appium and XCode
@@ -1190,6 +1212,13 @@ starting your Cucumber test suite(s):
 
     run_appium: APPIUM_SERVER=run
 
+If you are running locally hosted mobile tests on iOS or Android simulators or devices using version 1.x of the Appium server,
+the `APPIUM_SERVER_VERSION` environment variable must be set to `1` in order to ensure that the correct Appium server endpoint
+is used. This can be set by adding the following to your `cucumber.yml` file and including `-p appium_1x` in your command line
+when starting your Cucumber test suite(s):
+
+    appium_1x: APPIUM_SERVER_VERSION=1
+
 Refer to [**section 8.4 (Using Configuration Specific Profiles in `cucumber.yml`)**](#using-configuration-specific-profiles-in-cucumber-yml) below.
 
 
@@ -1210,6 +1239,10 @@ body of an example group:
       $server.stop if Environ.driver == :appium && $server.running?
     end
 ```
+If you are running locally hosted mobile tests on iOS or Android simulators or devices using version 1.x of the Appium server,
+the `APPIUM_SERVER_VERSION` environment variable must be set to `1` in order to ensure that the correct Appium server endpoint
+is used.
+
 
 ###  Connecting to Remote Cloud Hosted iOS and Android Simulators or Physical Devices
 
@@ -1632,6 +1665,7 @@ with access to your version control system.
     # physical devices
     #==============
     run_appium: APPIUM_SERVER=run
+    appium_1x: APPIUM_SERVER_VERSION=1
 
 
     #==============
@@ -1728,6 +1762,11 @@ run tests against an iPad Pro (12.9-inch) (5th generation) with iOS version 15.4
 You can ensure that Appium Server is running by including `-p run_appium` in your command line:
 
     cucumber -p ipad_pro_12_15_sim -p portrait -p run_appium
+
+If you are running locally hosted mobile tests using version 1.x of Appium server, you must include `-p appium_1x` in
+your command line:
+
+    cucumber -p ipad_pro_12_15_sim -p landscape -p run_appium -p appium_1x
 
 
 The following command specifies that Cucumber will run tests against a cloud hosted iPhone 13 Pro Max running iOS 15.4 on the

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -36,19 +36,19 @@ debug: DEBUG=true
 # test profiles
 #==============
 
-rn_bat_ios: --profile rn_demo --profile bat --profile ios_sim --profile report
-rn_bat_android: --profile rn_demo --profile bat --profile android_sim --profile report
-rn_regress_ios: --profile rn_demo --profile ios_caps_sim
-rn_regress_android: --profile rn_demo --profile android_caps_sim
+rn_bat_ios: -p rn_demo -p bat -p ios_sim -p report
+rn_bat_android: -p rn_demo -p bat -p android_sim -p report
+rn_regress_ios: -p rn_demo -p regress -p ios_caps_sim
+rn_regress_android: -p rn_demo -p regress -p android_caps_sim
 
-rn_deeplink_bs_ios17: --profile rn_demo --tags '@bs_deeplink' --profile bs_iphone_iOS17_caps
-rn_deeplink_bs_ios16: --profile rn_demo --tags '@bs_deeplink' --profile bs_iphone_iOS16_caps
-rn_deeplink_bs_android: --profile rn_demo --tags '@bs_deeplink' --profile bs_android_phone_caps
+rn_deeplink_bs_ios17: -p rn_demo --tags '@bs_deeplink' -p bs_iphone_iOS17_caps
+rn_deeplink_bs_ios16: -p rn_demo --tags '@bs_deeplink' -p bs_iphone_iOS16_caps
+rn_deeplink_bs_android: -p rn_demo --tags '@bs_deeplink' -p bs_android_phone_caps
 
-wdio_bat_android: --profile wdio_demo --profile bat --profile android_sim --profile report
-wdio_bat_ios: --profile wdio_demo --profile bat --profile ios_sim --profile report
-wdio_regress_android: --profile wdio_demo --profile android_caps_sim
-wdio_regress_ios: --profile wdio_demo --profile ios_caps_sim
+wdio_bat_android: -p wdio_demo -p bat -p android_sim -p report
+wdio_bat_ios: -p wdio_demo -p bat -p ios_sim -p report
+wdio_regress_android: -p wdio_demo -p regress -p android_caps_sim
+wdio_regress_ios: -p wdio_demo -p regress -p ios_caps_sim
 
 
   #==============
@@ -88,13 +88,13 @@ android: PLATFORM=android --tags @android -r features/support/android -e feature
 # NOTE: Requires installation of XCode, iOS version specific target simulators, and Appium
 #==============
 
-appium_ios: DRIVER=appium --profile ios AUTOMATION_ENGINE=XCUITest APP_PLATFORM_NAME="iOS" NEW_COMMAND_TIMEOUT="30" APP_NO_RESET=true
-app_ios_15: --profile appium_ios APP_VERSION="15.4"
+appium_ios: DRIVER=appium -p ios AUTOMATION_ENGINE=XCUITest APP_PLATFORM_NAME="iOS" NEW_COMMAND_TIMEOUT="30" APP_NO_RESET=true
+app_ios_17: -p appium_ios APP_VERSION="17.2"
 
-iphone_13PM_15_sim: --profile app_ios_15 DEVICE_TYPE=phone APP_DEVICE="iPhone 13 Pro Max"
-ipad_pro_12_15_sim: --profile app_ios_15 DEVICE_TYPE=tablet APP_DEVICE="iPad Pro (12.9-inch) (5th generation)"
-ios_sim:            --profile iphone_13PM_15_sim --profile json --profile run_appium
-ios_caps_sim:       W3C_CAPS=iPhone --profile ios --profile yaml --profile run_appium
+iphone_13PM_17_sim: -p app_ios_17 DEVICE_TYPE=phone APP_DEVICE="iPhone 13 Pro Max"
+ipad_pro_12_17_sim: -p app_ios_17 DEVICE_TYPE=tablet APP_DEVICE="iPad Pro (12.9-inch) (6th generation)"
+ios_sim:            -p iphone_13PM_17_sim -p json -p run_appium
+ios_caps_sim:       W3C_CAPS=iPhone -p ios -p yaml -p run_appium
 
 
 #==============
@@ -102,11 +102,11 @@ ios_caps_sim:       W3C_CAPS=iPhone --profile ios --profile yaml --profile run_a
 # NOTE: Requires installation of Android Studio, Android version specific virtual device simulators, and Appium
 #==============
 
-appium_android:    DRIVER=appium --profile android AUTOMATION_ENGINE=UiAutomator2 APP_PLATFORM_NAME="Android" APP_NO_RESET=true
-app_android_12:    --profile appium_android APP_VERSION="12.0" CHROMEDRIVER_EXECUTABLE="/Users/Shared/config/webdrivers/chromedriver"
-pixel_5_api31_sim: --profile app_android_12 DEVICE_TYPE=phone APP_DEVICE="Pixel_5_API_31"
-android_sim:       --profile pixel_5_api31_sim --profile json --profile run_appium
-android_caps_sim:  W3C_CAPS=android_phone --profile android --profile yaml --profile run_appium
+appium_android:    DRIVER=appium -p android AUTOMATION_ENGINE=UiAutomator2 APP_PLATFORM_NAME="Android" APP_NO_RESET=true
+app_android_12:    -p appium_android APP_VERSION="12.0" CHROMEDRIVER_EXECUTABLE="/Users/Shared/config/webdrivers/chromedriver"
+pixel_5_api31_sim: -p app_android_12 DEVICE_TYPE=phone APP_DEVICE="Pixel_5_API_31"
+android_sim:       -p pixel_5_api31_sim -p json -p run_appium
+android_caps_sim:  W3C_CAPS=android_phone -p android -p yaml -p run_appium
 
 
 #==============
@@ -116,16 +116,16 @@ android_caps_sim:  W3C_CAPS=android_phone --profile android --profile yaml --pro
 browserstack: DRIVER=browserstack TEST_CONTEXT="TestCentricity - BrowserStack"
 
 # BrowserStack iOS real device native app profiles
-bs_ios:          --profile browserstack --profile ios BS_OS=ios <%= mobile %>
-bs_iphone:       --profile bs_ios DEVICE_TYPE=phone
-bs_iphone_iOS17: --profile bs_iphone BS_OS_VERSION="17" BS_DEVICE="iPhone 15 Pro Max"
-bs_iphone_iOS17_caps: W3C_CAPS=bs_iPhoneOS17 --profile ios --profile yaml
-bs_iphone_iOS16_caps: W3C_CAPS=bs_iPhoneOS16 --profile ios --profile yaml
+bs_ios:          -p browserstack -p ios BS_OS=ios <%= mobile %>
+bs_iphone:       -p bs_ios DEVICE_TYPE=phone
+bs_iphone_iOS17: -p bs_iphone BS_OS_VERSION="17" BS_DEVICE="iPhone 15 Pro Max"
+bs_iphone_iOS17_caps: W3C_CAPS=bs_iPhoneOS17 -p ios -p yaml
+bs_iphone_iOS16_caps: W3C_CAPS=bs_iPhoneOS16 -p ios -p yaml
 
 # BrowserStack Android real device native app profiles
-bs_android: --profile browserstack --profile android BS_OS=android <%= mobile %>
-bs_pixel5:  --profile bs_android BS_DEVICE="Google Pixel 5" BS_OS_VERSION="12.0" DEVICE_TYPE=phone
-bs_android_phone_caps: W3C_CAPS=bs_android_phone --profile android --profile yaml
+bs_android: -p browserstack -p android BS_OS=android <%= mobile %>
+bs_pixel5:  -p bs_android BS_DEVICE="Google Pixel 5" BS_OS_VERSION="12.0" DEVICE_TYPE=phone
+bs_android_phone_caps: W3C_CAPS=bs_android_phone -p android -p yaml
 
 #==============
 # profiles for remotely hosted devices on the SauceLabs service
@@ -134,13 +134,13 @@ bs_android_phone_caps: W3C_CAPS=bs_android_phone --profile android --profile yam
 saucelabs: DRIVER=saucelabs DATA_CENTER="us-west-1" AUTOMATE_PROJECT="TestCentricity - SauceLabs"
 
 # SauceLabs iOS real device native app profiles
-sl_ios:           --profile saucelabs --profile ios SL_OS=ios <%= mobile %>
-sl_iphone:        --profile sl_ios DEVICE_TYPE=phone
-sl_iphone13PM_15: --profile sl_iphone SL_DEVICE="iPhone 13 Pro Max Simulator" SL_OS_VERSION="15.4"
+sl_ios:           -p saucelabs -p ios SL_OS=ios <%= mobile %>
+sl_iphone:        -p sl_ios DEVICE_TYPE=phone
+sl_iphone13PM_15: -p sl_iphone SL_DEVICE="iPhone 13 Pro Max Simulator" SL_OS_VERSION="15.4"
 
 # SauceLabs Android real device native app profiles
-sl_android: --profile saucelabs --profile android SL_OS=android <%= mobile %>
-sl_pixel5:  --profile sl_android SL_DEVICE="Google Pixel 5 GoogleAPI Emulator" SL_OS_VERSION="12.0" DEVICE_TYPE=phone
+sl_android: -p saucelabs -p android SL_OS=android <%= mobile %>
+sl_pixel5:  -p sl_android SL_DEVICE="Google Pixel 5 GoogleAPI Emulator" SL_OS_VERSION="12.0" DEVICE_TYPE=phone
 
 
 #==============
@@ -150,13 +150,13 @@ sl_pixel5:  --profile sl_android SL_DEVICE="Google Pixel 5 GoogleAPI Emulator" S
 testingbot: DRIVER=testingbot AUTOMATE_PROJECT="TestCentricity - TestingBot"
 
 # TestingBot iOS real device native app profiles
-tb_ios:               --profile testingbot --profile ios TB_OS=iOS <%= mobile %>
-tb_iphone:            --profile tb_ios DEVICE_TYPE=phone
-tb_iphone11_14_dev:   --profile tb_iphone TB_OS_VERSION="14.0" TB_DEVICE="iPhone 11" REAL_DEVICE=true
-tb_iphone11_14_sim:   --profile tb_iphone TB_OS_VERSION="14.2" TB_DEVICE="iPhone 11"
-tb_iphone13PM_15_sim: --profile tb_iphone TB_OS_VERSION="15.4" TB_DEVICE="iPhone 13 Pro Max"
+tb_ios:               -p testingbot -p ios TB_OS=iOS <%= mobile %>
+tb_iphone:            -p tb_ios DEVICE_TYPE=phone
+tb_iphone11_14_dev:   -p tb_iphone TB_OS_VERSION="14.0" TB_DEVICE="iPhone 11" REAL_DEVICE=true
+tb_iphone11_14_sim:   -p tb_iphone TB_OS_VERSION="14.2" TB_DEVICE="iPhone 11"
+tb_iphone13PM_15_sim: -p tb_iphone TB_OS_VERSION="15.4" TB_DEVICE="iPhone 13 Pro Max"
 
 # TestingBot Android real device native app profiles
-tb_android:    --profile testingbot --profile android TB_OS=Android <%= mobile %>
-tb_pixel_dev:  --profile tb_android TB_DEVICE="Pixel" TB_OS_VERSION="9.0" DEVICE_TYPE=phone REAL_DEVICE=true
-tb_pixel6_sim: --profile tb_android TB_DEVICE="Pixel 6" TB_OS_VERSION="12.0" DEVICE_TYPE=phone
+tb_android:    -p testingbot -p android TB_OS=Android <%= mobile %>
+tb_pixel_dev:  -p tb_android TB_DEVICE="Pixel" TB_OS_VERSION="9.0" DEVICE_TYPE=phone REAL_DEVICE=true
+tb_pixel6_sim: -p tb_android TB_DEVICE="Pixel 6" TB_OS_VERSION="12.0" DEVICE_TYPE=phone

--- a/config/test_data/RN_DEMO_data.yml
+++ b/config/test_data/RN_DEMO_data.yml
@@ -7,7 +7,7 @@ Capabilities:
     :driver_name: :iphone_driver
     :capabilities:
       :platformName: :ios
-      :'appium:platformVersion': '15.4'
+      :'appium:platformVersion': '17.2'
       :'appium:deviceName': 'iPhone 13 Pro Max'
       :'appium:automationName': 'XCUITest'
       :'appium:app': '/Users/Shared/Test_Apps/iOS/MyRNDemoApp.app'
@@ -18,8 +18,8 @@ Capabilities:
     :driver_name: :ipad_driver
     :capabilities:
       :platformName: :ios
-      :'appium:platformVersion': '15.4'
-      :'appium:deviceName': 'iPad Pro (12.9-inch) (5th generation)'
+      :'appium:platformVersion': '17.2'
+      :'appium:deviceName': 'iPad Pro (12.9-inch) (6th generation)'
       :'appium:automationName': 'XCUITest'
       :'appium:orientation': 'PORTRAIT'
       :'appium:app': '/Users/Shared/Test_Apps/iOS/MyRNDemoApp.app'

--- a/config/test_data/WDIO_DEMO_data.yml
+++ b/config/test_data/WDIO_DEMO_data.yml
@@ -7,7 +7,7 @@ Capabilities:
     :driver_name: :iphone_driver
     :capabilities:
       :platformName: :ios
-      :'appium:platformVersion': '15.4'
+      :'appium:platformVersion': '17.2'
       :'appium:deviceName': 'iPhone 13 Pro Max'
       :'appium:automationName': 'XCUITest'
       :'appium:app': '/Users/Shared/Test_Apps/iOS/wdiodemoapp.app'
@@ -18,8 +18,8 @@ Capabilities:
     :driver_name: :ipad_driver
     :capabilities:
       :platformName: :ios
-      :'appium:platformVersion': '15.4'
-      :'appium:deviceName': 'iPad Pro (12.9-inch) (5th generation)'
+      :'appium:platformVersion': '17.2'
+      :'appium:deviceName': 'iPad Pro (12.9-inch) (6th generation)'
       :'appium:automationName': 'XCUITest'
       :'appium:orientation': 'PORTRAIT'
       :'appium:app': '/Users/Shared/Test_Apps/iOS/wdiodemoapp.app'

--- a/features/support/android/rn_demo_app/screens/geo_location_screen.rb
+++ b/features/support/android/rn_demo_app/screens/geo_location_screen.rb
@@ -24,10 +24,6 @@ class GeoLocationScreen < BaseRNDemoAppScreen
         exists: true,
         disabled: false,
         hidden: false,
-        width: 416,
-        height: 74,
-        x: 55,
-        y: 273,
         class: 'android.widget.TextView'
       },
       start_observing_button => {

--- a/features/support/ios/rn_demo_app/screens/geo_location_screen.rb
+++ b/features/support/ios/rn_demo_app/screens/geo_location_screen.rb
@@ -25,11 +25,7 @@ class GeoLocationScreen < BaseRNDemoAppScreen
         caption: 'Geo Location',
         exists: true,
         disabled: false,
-        hidden: false,
-        width: 428,
-        height: 86,
-        x: 0,
-        y: 70
+        hidden: false
       },
       start_observing_button => {
         visible: true,

--- a/features/wdio_demo/form_components.feature
+++ b/features/wdio_demo/form_components.feature
@@ -1,4 +1,4 @@
-@mobile @ios @android @regression @wdio_demo @bat
+@mobile @ios @android @regression @wdio_demo
 
 
 Feature:  Form Components
@@ -20,7 +20,7 @@ Feature:  Form Components
     When I type text into the input field
     Then I expect what I typed to be displayed in the result field
 
-
+@bat
   Scenario:  Verify toggle switch
     When I turn the switch on
     Then I expect the switch on state to be correctly displayed
@@ -34,7 +34,7 @@ Feature:  Form Components
     When I close the drop-down menu
     Then I expect the drop-down menu to be closed
 
-
+@bat
   Scenario Outline:  Verify selection made from drop-menu
     When I open the drop-down menu
     And I select an item in the menu by its <method>
@@ -49,7 +49,7 @@ Feature:  Form Components
     |method |
     |index  |
 
-
+@bat
   Scenario Outline:  Verify alert modal interactions
     When I tap the Active button
     Then the popup request modal should be visible

--- a/features/wdio_demo/swipe.feature
+++ b/features/wdio_demo/swipe.feature
@@ -1,4 +1,4 @@
-@mobile @ios @android @regression @wdio_demo @bat
+@mobile @ios @android @regression @wdio_demo
 
 
 Feature:  Swipe
@@ -11,7 +11,7 @@ Feature:  Swipe
     Given I have launched the WDIO Demo app
     And I am on the Swipe screen
 
-
+@bat
   Scenario:  Verify horizontal scrolling gestures
     Then I expect the Swipe screen to be correctly displayed
 

--- a/lib/testcentricity_mobile/app_core/appium_connect_helper.rb
+++ b/lib/testcentricity_mobile/app_core/appium_connect_helper.rb
@@ -390,7 +390,13 @@ module TestCentricity
 
     def self.appium_local_capabilities
       # specify endpoint url
-      @endpoint = 'http://127.0.0.1:4723/wd/hub' if @endpoint.nil?
+      if @endpoint.nil?
+        @endpoint = if ENV['APPIUM_SERVER_VERSION'] && ENV['APPIUM_SERVER_VERSION'].to_i == 1
+                      'http://127.0.0.1:4723/wd/hub'
+                    else
+                      'http://127.0.0.1:4723'
+                    end
+      end
       # define local Appium capabilities
       if @capabilities.nil?
         Environ.device_name = ENV['APP_DEVICE']
@@ -459,11 +465,7 @@ module TestCentricity
         Environ.device_name = @capabilities[:'appium:deviceName']
         Environ.device_os_version = @capabilities[:'appium:platformVersion']
         Environ.device_orientation = @capabilities[:'appium:orientation']
-        Environ.device = if @capabilities[:'appium:udid']
-                           :device
-                         else
-                           :simulator
-                         end
+        Environ.device = @capabilities[:'appium:udid'] ? :device : :simulator
         @capabilities
       end
     end

--- a/lib/testcentricity_mobile/appium_server.rb
+++ b/lib/testcentricity_mobile/appium_server.rb
@@ -38,9 +38,14 @@ module TestCentricity
     # Check to see if Appium Server is running
     #
     def running?
+      endpoint = if ENV['APPIUM_SERVER_VERSION'] && ENV['APPIUM_SERVER_VERSION'].to_i == 1
+                   'http://0.0.0.0:4723/wd/hub/sessions'
+                 else
+                   'http://0.0.0.0:4723/sessions'
+                 end
       response = false
       begin
-        response = Net::HTTP.get_response(URI('http://0.0.0.0:4723/wd/hub/sessions'))
+        response = Net::HTTP.get_response(URI(endpoint))
       rescue
       end
       response && response.code_type == Net::HTTPOK

--- a/lib/testcentricity_mobile/version.rb
+++ b/lib/testcentricity_mobile/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityMobile
-  VERSION = '4.0.2'
+  VERSION = '4.0.3'
 end

--- a/spec/testcentricity/connect_specs/appium_local_sim_spec.rb
+++ b/spec/testcentricity/connect_specs/appium_local_sim_spec.rb
@@ -23,7 +23,7 @@ describe TestCentricity::AppiumConnect, required: true do
           capabilities: {
             platformName: :ios,
             browserName: :safari,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path
@@ -38,7 +38,7 @@ describe TestCentricity::AppiumConnect, required: true do
           device_type: :phone,
           capabilities: {
             platformName: :ios,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path
@@ -52,7 +52,7 @@ describe TestCentricity::AppiumConnect, required: true do
           driver: :appium,
           capabilities: {
             platformName: :ios,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path
@@ -66,7 +66,7 @@ describe TestCentricity::AppiumConnect, required: true do
           device_type: :phone,
           capabilities: {
             platformName: :ios,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path
@@ -81,10 +81,10 @@ describe TestCentricity::AppiumConnect, required: true do
         {
           driver: :appium,
           device_type: :phone,
-          endpoint: 'http://127.0.0.1:4723/wd/hub',
+          endpoint: 'http://127.0.0.1:4723',
           capabilities: {
             platformName: :ios,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path,
@@ -99,7 +99,7 @@ describe TestCentricity::AppiumConnect, required: true do
         verify_mobile_connect(
           dev_type = :phone,
           dev_os = :ios,
-          os_version = '15.4',
+          os_version = '17.2',
           dev_name = 'iPhone 13 Pro Max'
         )
         expect($driver).to eq(nil)
@@ -112,7 +112,7 @@ describe TestCentricity::AppiumConnect, required: true do
           driver_name: :my_custom_iphone_driver,
           capabilities: {
             platformName: :ios,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path
@@ -122,7 +122,7 @@ describe TestCentricity::AppiumConnect, required: true do
         verify_mobile_connect(
           dev_type = :phone,
           dev_os = :ios,
-          os_version = '15.4',
+          os_version = '17.2',
           dev_name = 'iPhone 13 Pro Max',
           driver_name = :my_custom_iphone_driver
         )
@@ -182,7 +182,7 @@ describe TestCentricity::AppiumConnect, required: true do
           global_driver: true,
           capabilities: {
             platformName: :ios,
-            'appium:platformVersion': '15.4',
+            'appium:platformVersion': '17.2',
             'appium:deviceName': 'iPhone 13 Pro Max',
             'appium:automationName': 'XCUITest',
             'appium:app': Environ.current.ios_app_path
@@ -192,7 +192,7 @@ describe TestCentricity::AppiumConnect, required: true do
         verify_mobile_connect(
           dev_type = :phone,
           dev_os = :ios,
-          os_version = '15.4',
+          os_version = '17.2',
           dev_name = 'iPhone 13 Pro Max'
         )
         expect($driver).to eq(Environ.appium_driver)
@@ -204,7 +204,7 @@ describe TestCentricity::AppiumConnect, required: true do
         {
           driver: :appium,
           device_type: :phone,
-          endpoint: 'http://127.0.0.1:4723/wd/hub',
+          endpoint: 'http://127.0.0.1:4723',
           capabilities: {
             platformName: :android,
             'appium:platformVersion': '12.0',
@@ -256,17 +256,11 @@ describe TestCentricity::AppiumConnect, required: true do
         expect(AppiumConnect.app_installed?).to eq(true)
         expect(AppiumConnect.app_state).to eq(:running_in_foreground)
         expect(AppiumConnect.orientation).to eq(:portrait)
-        expect(AppiumConnect.window_size).to eq([1080, 2208])
         expect(AppiumConnect.keyboard_shown?).to eq(false)
         expect(AppiumConnect.current_context).to eq('NATIVE_APP')
         expect(AppiumConnect.available_contexts).to eq(['NATIVE_APP'])
         expect(AppiumConnect.is_webview?).to eq(false)
         expect(AppiumConnect.is_native_app?).to eq(true)
-        rect = AppiumConnect.window_rect
-        expect(rect.x).to eq(0)
-        expect(rect.y).to eq(0)
-        expect(rect.width).to eq(1080)
-        expect(rect.height).to eq(2208)
       end
 
       it 'verifies Android app is terminated' do
@@ -317,14 +311,14 @@ describe TestCentricity::AppiumConnect, required: true do
     it 'connects to iOS iPhone Simulator using environment variables' do
       ENV['AUTOMATION_ENGINE'] = 'XCUITest'
       ENV['APP_PLATFORM_NAME'] = 'ios'
-      ENV['APP_VERSION'] = '15.4'
+      ENV['APP_VERSION'] = '17.2'
       ENV['APP_DEVICE'] = 'iPhone 13 Pro Max'
       ENV['APP'] = Environ.current.ios_app_path
       AppiumConnect.initialize_appium
       verify_mobile_connect(
         dev_type = :phone,
         dev_os = :ios,
-        os_version = '15.4',
+        os_version = '17.2',
         dev_name = 'iPhone 13 Pro Max'
       )
       expect($driver).to eq(nil)


### PR DESCRIPTION
* `AppiumConnect.initialize_appium`  and `AppiumServer.running?` methods now support Appium version 2.x. Backward compatibility with Appium version 1.x is provided if `APPIUM_SERVER_VERSION` Environment Variable is set to `1`.
* Update iOS config data, `cucumber.yml` profiles, and local sim specs to run tests on iOS v17.2 simulators.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules