### PR TITLE
Update selenium_webdriver and appium_lib gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.0.4] - 26-APR-2024
+
+### Changed
+
+* Updated `selenium-webdriver` gem to version 4.20.0.
+* Updated `appium_lib` gem to version 15.0.0.
+* Updated `appium_lib_core` gem to version 8.0.1.
+* No longer using deprecated Appium `driver.keyboard_shown?` method.
+
+
 ## [4.0.3] - 05-APR-2024
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,22 +33,23 @@ Mobile can be found at the following:
   * [tc_mobile_react_native_demo](https://github.com/TestCentricity/tc_mobile_react_native_demo)
   * [tc_mobile_wdio_demo](https://github.com/TestCentricity/tc_mobile_wdio_demo)
 
-Refer to [this wiki page](https://github.com/TestCentricity/testcentricity_mobile/wiki/XCUItest-driver-bug-impacts-iOS-dialogs-managed-by-com.apple.springboard) for
-information on a bug with the latest versions of the XCUItest driver that affects Appium's ability to interact with and
-verify iOS system level modal dialogs.
+Refer to [this wiki page](https://github.com/TestCentricity/testcentricity_mobile/wiki/XCUItest-driver-bug-impacts-iOS-dialogs-managed-by-com.apple.springboard) for information on a bug with the latest versions of the XCUItest driver that affects Appium's
+ability to interact with and verify iOS system level modal dialogs.
 
 
 ### Which gem should I use?
 
 * The [TestCentricity **Mobile** gem](https://rubygems.org/gems/testcentricity_mobile) only supports testing of native iOS and Android mobile apps
+* The [TestCentricity **Apps** gem](https://rubygems.org/gems/testcentricity_apps) only supports testing of MacOS desktop apps and native iOS and Android mobile apps
 * The [TestCentricity **Web** gem](https://rubygems.org/gems/testcentricity_web) only supports testing of web interfaces via desktop and mobile web browsers
 * The TestCentricity gem supports testing of native mobile apps and/or web interfaces via desktop and mobile web browsers.
 
-| Tested platforms                                   | TestCentricity Mobile | TestCentricity Web | TestCentricity |
-|----------------------------------------------------|-----------------------|--------------------|----------------|
-| Native mobile iOS and/or Android apps only         | Yes                   | No                 | No             |
-| Desktop/mobile web browsers only                   | No                    | Yes                | No             |
-| Native mobile apps and desktop/mobile web browsers | No                    | No                 | Yes            |
+| Tested platforms                                   | TestCentricity Mobile | TestCentricity Apps | TestCentricity Web | TestCentricity |
+|----------------------------------------------------|-----------------------|---------------------|--------------------|----------------|
+| Native mobile iOS and/or Android apps only         | Yes                   | Yes                 | No                 | No             |
+| MacOS desktop apps                                 | No                    | Yes                 | No                 | No             |
+| Desktop/mobile web browsers only                   | No                    | No                  | Yes                | No             |
+| Native mobile apps and desktop/mobile web browsers | No                    | No                  | No                 | Yes            |
 
 
 ## Installation

--- a/lib/testcentricity_mobile/app_core/appium_connect_helper.rb
+++ b/lib/testcentricity_mobile/app_core/appium_connect_helper.rb
@@ -214,7 +214,7 @@ module TestCentricity
     # @return [Boolean] TRUE if keyboard is shown. Return false if keyboard is hidden.
     #
     def self.keyboard_shown?
-      driver.driver.keyboard_shown?
+      @driver.execute_script('mobile: isKeyboardShown')
     end
 
     # Get the current screen orientation

--- a/lib/testcentricity_mobile/app_core/screen_objects_helper.rb
+++ b/lib/testcentricity_mobile/app_core/screen_objects_helper.rb
@@ -125,7 +125,8 @@ module TestCentricity
                      ui_object.count
                    when :buttons
                      ui_object.buttons
-
+                   else
+                     raise "#{property} is not a valid property"
                    end
           error_msg = "Expected UI object '#{ui_object.get_name}' (#{ui_object.get_locator}) #{property} property to"
           ExceptionQueue.enqueue_comparison(ui_object, state, actual, error_msg)

--- a/lib/testcentricity_mobile/version.rb
+++ b/lib/testcentricity_mobile/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityMobile
-  VERSION = '4.0.3'
+  VERSION = '4.0.4'
 end

--- a/testcentricity_mobile.gemspec
+++ b/testcentricity_mobile.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.requirements  << 'Appium'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'cucumber', '9.1.2'
+  spec.add_development_dependency 'cucumber', '9.2.0'
   spec.add_development_dependency 'parallel_tests'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'require_all', '=1.5.0'
@@ -39,13 +39,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', ['~> 0.18']
   spec.add_development_dependency 'yard', ['>= 0.9.0']
 
-  spec.add_runtime_dependency 'appium_lib', '~> 14.0.0'
+  spec.add_runtime_dependency 'appium_lib', '~> 15.0.0'
   spec.add_runtime_dependency 'childprocess'
   spec.add_runtime_dependency 'chronic', '0.10.2'
   spec.add_runtime_dependency 'faker'
   spec.add_runtime_dependency 'i18n'
   spec.add_runtime_dependency 'json'
-  spec.add_runtime_dependency 'selenium-webdriver', '4.19.0'
+  spec.add_runtime_dependency 'selenium-webdriver', '4.20.0'
   spec.add_runtime_dependency 'test-unit'
   spec.add_runtime_dependency 'virtus'
 end


### PR DESCRIPTION
## Proposed changes

* Updated `selenium_webdriver` gem to version 4.20.0.
* Updated `appium_lib` gem to version 15.0.0.
* Updated `appium_lib_core` gem to version 8.0.1.
* Don't use deprecated Appium `driver.keyboard_shown?` method## Types of changes

What types of changes does your code introduce to TestCentricity Mobile?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
