### PR TITLE
Fix ScreenSection.find_section bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.0.6] - 02-MAY-2024
+
+### Fixed
+
+* `ScreenSection.find_section` is now able to find `ScreenSection` objects embedded within other `ScreenSections`.
+
+
 ## [4.0.5] - 29-APR-2024
 
 ### Fixed

--- a/lib/testcentricity_mobile/app_core/screen_section.rb
+++ b/lib/testcentricity_mobile/app_core/screen_section.rb
@@ -20,14 +20,14 @@ module TestCentricity
     end
 
     def get_locator
-      if @locator.zero? && defined?(section_locator)
-        my_locator = section_locator
-      else
-        my_locator = @locator
-      end
+      my_locator = if @locator.zero? && defined?(section_locator)
+                     section_locator
+                   else
+                     @locator
+                   end
       locators = []
       if @context == :section && !@parent.nil?
-        locators.push(@parent.get_locator)
+        locators = @parent.get_locator
       end
 
       if @parent_list.nil?
@@ -578,11 +578,10 @@ module TestCentricity
       locators.each do |loc|
         if obj.nil?
           obj = find_element(loc.keys[0], loc.values[0])
-          puts "Found object #{loc}" if ENV['DEBUG']
         else
           obj = obj.find_element(loc.keys[0], loc.values[0])
-          puts "Found object #{loc}" if ENV['DEBUG']
         end
+        puts "Found section object #{loc}" if ENV['DEBUG']
       end
       obj
     rescue

--- a/lib/testcentricity_mobile/version.rb
+++ b/lib/testcentricity_mobile/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityMobile
-  VERSION = '4.0.5'
+  VERSION = '4.0.6'
 end


### PR DESCRIPTION
`ScreenSection.find_section` is now able to find `ScreenSection` objects embedded within other `ScreenSections`. Fixes bug #10 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules